### PR TITLE
Fix spurrious \+ in code sample

### DIFF
--- a/book/Strings.tex
+++ b/book/Strings.tex
@@ -992,7 +992,7 @@ the following code, the \verb'\d+' matches one or more
 digits (three digits in this case):
 
 \begin{verbatim}
-say ~$/ if 'Bond 007' ~~ /\w\D\s\d\+/;  # -> "nd 007"
+say ~$/ if 'Bond 007' ~~ /\w\D\s\d+/;  # -> "nd 007"
 \end{verbatim}
 %
 


### PR DESCRIPTION
Somehow \d+ turned into \d\+