### PR TITLE
Add Makefile and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+book/*.aux
+book/*.idx
+book/*.log
+book/*.out
+book/*.synctex.gz
+book/*.toc
+book/*.pdf
+book/tmpDir/*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ alonside other intermediate files created during the compilation process.
 
 To move the created pdf to the directory `PDF` in the root directory, run:
 ```
-make PDF
+make pdf
 ```
 
 To remove `tmpDir`, run:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # thinkperl6
+
+### Generating the PDF
+
+The directory `book` contains the LaTeX sources needed to compile the book.
+To recompile it, run the following command within the directory:
+```
+make
+```
+This command will create the directory `tmpDir` where you'll find the PDF (thinkperl6.pdf)
+alonside other intermediate files created during the compilation process.
+
+To move the created pdf to the directory `PDF` in the root directory, run:
+```
+make PDF
+```
+
+To remove `tmpDir`, run:
+```
+make clean
+```
+**Note**: The chances of a successful compilation increase if you have an almost
+complete installation of a recent TeX Live distribution.
+
+

--- a/book/Makefile
+++ b/book/Makefile
@@ -1,0 +1,45 @@
+### Input and output files/dir
+FILENAME = thinkperl6
+OUTPUT_NAME = thinkperl6
+PDF_OUTPUT = xelatex
+DIR_NAME = tmpDir
+
+
+### Compilation flags for pdflatex, xelatex, etc.
+PDFLATEX_FLAGS = -halt-on-error\
+				 -interaction=batchmode\
+				 -output-format pdf\
+				 -output-directory tmpDir\
+				 -jobname=$(OUTPUT_NAME)
+XELATEX_FLAGS = -halt-on-error\
+				-interaction=batchmode\
+			    -output-directory tmpDir\
+			    -jobname=$(OUTPUT_NAME)
+
+TEXINPUTS = .:$(DIR_NAME)/
+TEXMFOUTPUT = $(DIR_NAME)
+
+### Choose TeX engine
+FLAGS = $(XELATEX_FLAGS)
+
+### Compile tex into pdf
+all: $(DIR_NAME)/$(FILENAME).pdf
+
+$(DIR_NAME)/:
+	mkdir -p $(DIR_NAME)
+
+$(DIR_NAME)/$(FILENAME).aux: $(DIR_NAME)/
+	$(PDF_OUTPUT) $(FLAGS) $(FILENAME)
+
+$(DIR_NAME)/$(FILENAME).pdf: $(DIR_NAME)/$(FILENAME).aux
+	$(PDF_OUTPUT) $(FLAGS) $(FILENAME)
+
+### Clean
+# Clean temporary files (including created PDF file) by removing
+# the directory tmpDir/ created during the compilation process.
+
+pdf:
+	mv ./$(DIR_NAME)/$(FILENAME).pdf ../PDF/
+
+clean:
+	rm -rfv $(DIR_NAME)

--- a/book/data_struct_selection.tex
+++ b/book/data_struct_selection.tex
@@ -544,6 +544,7 @@ sub process-line(Str $line is copy) {
     for $line.words -> $word {
         %histogram{$word}++;
     }
+	$skip = True if $line ~~ /^finis$/;
 }
 process-line $_ for "emma.txt".IO.lines; 
 \end{verbatim}
@@ -875,7 +876,7 @@ to use two hashes as operands:
 my %unknown-words = %histogram - %word-list;
 \end{verbatim}
 
-The rest or the program works just as before.
+The rest of the program works just as before.
 
 \index{extending the language}
 This ease or creating new operators is one of the facilities 


### PR DESCRIPTION
I added a Makefile so that it's easier to compile the pdf from the LaTeX sources. Following, I updated the README with some instructions on generating the pdf using make. 

While running the `process-line` subroutine over the `emma.txt` file, I noticed it was counting the words in the line after the end of the book so I added a simple conditional to the function to flag the end of the book in that specific file.